### PR TITLE
add kubernetes-intro task

### DIFF
--- a/kubernetes-intro/namespace.yaml
+++ b/kubernetes-intro/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-intro/pod.yaml
+++ b/kubernetes-intro/pod.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: homework
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      ports:
+        - containerPort: 8000
+      lifecycle:
+        preStop:
+          exec:
+            command: [ "rm", "-f", "/homework/index.html" ]
+      volumeMounts:
+        - name: front-static
+          mountPath: "/homework"
+        - name: nginx-conf
+          mountPath: /etc/nginx/conf.d/
+          # subPath: default2
+
+  initContainers:
+    - name: download-static
+      image: busybox:1.28
+      command: 
+          - wget
+          - "-O"
+          - "/init/index.html"
+          - http://info.cern.ch
+      volumeMounts:
+        - name: front-static
+          mountPath: "/init"
+
+  volumes:
+    - name: front-static
+
+
+
+      # Это для выполнения условия: 
+      # Будет иметþ контейнер, поднимаĀûий веб-сервер на
+      # 8000 порту и отдаĀûий содержимое папки /homework
+      # внутри ÿтого контейнера.
+    - name: nginx-conf 
+      configMap:
+        name: nginx-conf
+        items:
+        - key: default.conf
+          path: default.conf
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+
+        server_name _;
+        root /homework;
+        index index.html;
+        location / { 
+          try_files $uri $uri/ /index.html;
+        }
+    }
+    


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [x] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Установлена на HyperV ubuntu 22
 - развернут и установлены docker, minikube и kubectl  методом установки бинарника
 - созданы 2 манифеста - для создания ns и pod.
 - Для выполнения условий задачи я выбрал применение configMap содержащего конфиг веб-сервера nginx.

## Как запустить проект:
 условия: на машине должны быть kubectl и доступный кластер кубернетиса
 - git clone https://github.com/Kuber-2025-02OTUS/VChernyshoff_repo.git
 - cd VChernyshoff_repo
 - git checkout kubernetes-intro 
 - cd kubernetes-intro
 - kubectl apply -f namespace.yaml && kubectl apply -f pod.yaml

## Как проверить работоспособность:
 - в одном терминале сделать проброс порта, в другом выполнить curl
 - kube port-forward -n homework nginx 8000:8000
 - curl localhost:8000
 - в ответ должны получить html страницу.

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
