### PR TITLE
add homework 2

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: homework
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector:
+        homework: "true"
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /homework/index.html
+            initialDelaySeconds: 0
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "rm", "-f", "/homework/index.html" ]
+          volumeMounts:
+            - name: front-static
+              mountPath: "/homework"
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+      initContainers:
+        - name: download-static
+          image: busybox:1.28
+          command: 
+              - wget
+              - "-O"
+              - "/init/index.html"
+              - http://info.cern.ch
+          volumeMounts:
+            - name: front-static
+              mountPath: "/init"
+      volumes:
+        - name: front-static
+        - name: nginx-conf 
+          configMap:
+            name: nginx-conf
+            items:
+            - key: default.conf
+              path: default.conf
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+
+        server_name _;
+        root /homework;
+        index index.html;
+        location / { 
+          try_files $uri $uri/ /index.html;
+        }
+    }
+    

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - создан манифест namespace.yaml который создает ns homework
 - создан манифест deployment.yaml который создается в ns homework, поднимает 3 пода из предыдущего занятия
 - в deployment реализована readiness проба на наличие файла /homework/index.html
 - указана стратегия обновления RollingUpdate, настроенную так, что в процессе обновления может быть недоступен максимум 1 под
- добавлена опция, обеспечивающая запуск подов только на нодах кластера с меткой homework=true

## Как запустить проект:
  условия: на машине должны быть kubectl и доступный кластер кубернетиса, хотя бы одна worker нода должна иметь метку  homework=true
  
- git clone https://github.com/Kuber-2025-02OTUS/VChernyshoff_repo.git
- cd VChernyshoff_repo
- git checkout kubernetes-controllers
- cd kubernetes-controllers
- kubectl apply -f namespace.yaml && kubectl apply -f deployment.yaml


## Как проверить работоспособность:
- kubectl get pods -n homework - должно отдать 3 пода ginx-deployment-...
- если из манифеста убрать/закомментировать initContainer, то под должен свалится по readinessProbe
- при обновлении приложения, в один момент времени должен быть недоступен только один из 3х подов 
- если  ни одна worker нода не будет иметь метку  homework=true, то поды будут в статусе pending

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
