### PR TITLE
add kubernetes-networks

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: homework
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      # nodeSelector:
+      #   homework: "true"
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+            initialDelaySeconds: 0
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "rm", "-f", "/homework/index.html" ]
+          volumeMounts:
+            - name: front-static
+              mountPath: "/homework"
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+      initContainers:
+        - name: download-static
+          image: busybox:1.28
+          command: 
+              - wget
+              - "-O"
+              - "/init/index.html"
+              - http://info.cern.ch
+          volumeMounts:
+            - name: front-static
+              mountPath: "/init"
+      volumes:
+        - name: front-static
+        - name: nginx-conf 
+          configMap:
+            name: nginx-conf
+            items:
+            - key: default.conf
+              path: default.conf
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+
+        server_name _;
+        root /homework;
+        index index.html;
+        location / { 
+          try_files $uri $uri/ /index.html;
+        }
+    }
+    

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -4,11 +4,10 @@ metadata:
   namespace: homework
   name: nginx-ingress
   annotations:
-      kubernetes.io/ingress.class: "nginx"
-      nginx.ingress.kubernetes.io/rewrite-target: http://homework.otus/index.html
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
 
 spec:
-  ingressClassName: nginx
+  # ingressClassName: nginx
   rules:
     - host: "homework.otus"
       http:
@@ -18,6 +17,12 @@ spec:
             backend:
               service:
                 name: nginx-service
-                # namespace: homework
+                port:
+                  number: 8000
+          - path: /homepage
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
                 port:
                   number: 8000

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: homework
+  name: nginx-ingress
+  annotations:
+      kubernetes.io/ingress.class: "nginx"
+      nginx.ingress.kubernetes.io/rewrite-target: http://homework.otus/index.html
+
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "homework.otus"
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                # namespace: homework
+                port:
+                  number: 8000

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Изменена readiness-проба в манифесте deployment.yaml из прошлого ДЗ на httpGet, вызывающая URL /index.html
 - создан манифест service.yaml, описывающий сервис типа ClusterIP, который будет направлять трафик на поды,
управляемые deployment
- установлен в миникуб ingress-controller с помощью addons enable ingress
- Создан манифест ingress.yaml, в котором описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис. 
- * описано в аннотации к ингресс  rewrite-правило, чтобы обращение по адресу http://homework.otus/homepage
форвардилось на http://homework.otus/index.html. Ну получилось так, что любые обращения туда форвардятся.

## Как запустить проект:
- у вас запущен кластер, в котором есть ингресс-контроллер
 - применить манифесты с помощью kubectl apply -f: namespace.yaml, deployment.yaml, service.yaml, ingress.yaml  

## Как проверить работоспособность:
 - узнать адрес ноды. В моем примере, это миникуб - minikube ip
 - сделать запись в /etc/hosts: homework.otus ${ip полученный выше}
 - сделать curl http://homework.otus/index.html - в ответ должны получить html страницу.
 - сделать curl http://homework.otus/homework - в ответ должны получить ту же страницу.
 - для проверки редиректа выполнить curl -I http://homework.otus/homework - должны увидеть код ответа HTTP/1.1 302 Moved Temporarily и Location: http://homework.otus/index.html
 - если не работает, возможно, сможет помочь minikube tunnel

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
