### PR TITLE
hw storage

### DIFF
--- a/kubernetes-volumes/cm.yaml
+++ b/kubernetes-volumes/cm.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hw-configmap
+  namespace: homework
+data:
+  key1: value1
+  key2: value2
+  test: test1
+  

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -56,6 +56,8 @@ spec:
               mountPath: "/init"
       volumes:
         - name: hw-pvc
+          persistentVolumeClaim:
+              claimName: hw-pvc
         - name: hw-configmap
           configMap:
             name: hw-configmap

--- a/kubernetes-volumes/deployment.yaml
+++ b/kubernetes-volumes/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: homework
+  name: nginx-deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      # nodeSelector:
+      #   homework: "true"
+      containers:
+        - name: nginx
+          image: nginx:latest
+          ports:
+            - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+            initialDelaySeconds: 0
+            periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "rm", "-f", "/homework/index.html" ]
+          volumeMounts:
+            - name: hw-pvc
+              mountPath: "/homework"
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d/
+            - name: hw-configmap
+              mountPath: /homework/conf
+      initContainers:
+        - name: download-static
+          image: busybox:1.28
+          command: 
+              - wget
+              - "-O"
+              - "/init/index.html"
+              - http://info.cern.ch
+          volumeMounts:
+            - name: hw-pvc
+              mountPath: "/init"
+      volumes:
+        - name: hw-pvc
+        - name: hw-configmap
+          configMap:
+            name: hw-configmap
+        - name: nginx-conf 
+          configMap:
+            name: nginx-conf
+            items:
+            - key: default.conf
+              path: default.conf
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  default.conf: |
+    server {
+        listen 8000;
+
+        server_name _;
+        root /homework;
+         index index.html;
+        location / { 
+          try_files $uri $uri/ /index.html;
+        }
+    }
+    

--- a/kubernetes-volumes/ingress.yaml
+++ b/kubernetes-volumes/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: homework
+  name: nginx-ingress
+  annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /$1
+
+spec:
+  # ingressClassName: nginx
+  rules:
+    - host: "homework.otus"
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 8000
+          - path: /homepage
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 8000
+          - path: /conf
+            pathType: Prefix
+            backend:
+              service:
+                name: nginx-service
+                port:
+                  number: 8000

--- a/kubernetes-volumes/namespace.yaml
+++ b/kubernetes-volumes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hw-pvc
+  namespace: homework
+spec:
+  storageClassName: "hw" # Empty string must be explicitly set otherwise default StorageClass will be set
+  volumeName: hw-pvc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+---

--- a/kubernetes-volumes/pvc.yaml
+++ b/kubernetes-volumes/pvc.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: homework
 spec:
   storageClassName: "hw" # Empty string must be explicitly set otherwise default StorageClass will be set
-  volumeName: hw-pvc
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
-      storage: 1Gi
+      storage: 100Mi
 ---

--- a/kubernetes-volumes/service.yaml
+++ b/kubernetes-volumes/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000

--- a/kubernetes-volumes/storageClass.yaml
+++ b/kubernetes-volumes/storageClass.yaml
@@ -1,0 +1,17 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"},"labels":{"addonmanager.kubernetes.io/mode":"EnsureExists"},"name":"standard"},"provisioner":"k8s.io/minikube-hostpath"}
+    storageclass.kubernetes.io/is-default-class: "true"
+  creationTimestamp: "2025-03-17T18:57:57Z"
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: hw
+  namespace: homework
+  resourceVersion: "271"
+  uid: 750df63d-6f20-4b1c-8a43-bf13cbbe8dc2
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain
+volumeBindingMode: Immediate


### PR DESCRIPTION
# Выполнено ДЗ №4

 - [ ] Основное ДЗ
 - [ ] Задание со *

## В процессе сделано:
 - Создан манифест pvc.yaml, описывающий PersistentVolumeClaim hw-pvc, запрашивающий хранилище с storageClass по-умолчанию
 - Создан манифест cm.yaml для объекта типа configMap, описывающий набор трех пар ключ-значение
 - В манифесте deployment.yaml изменена спецификация volume, который монтируется в init и основной контейнер, на pvc, созданный в предыдущем пункте (hw-pvc)
- В манифесте deployment.yaml добавлено монтирование ранее созданного configMap как volume к основному контейнеру пода в директорию /homework/conf, так, чтобы его содержимое было из cinfigmap. Но содержимое не удается получить, обратившись по url/conf/file (в моем случае http://homework.otus/homework/conf/key1)


Задание с *
● Создан манифест storageClass.yaml описывающий объект типа storageClass с provisioner k8s.io/minikube-hostpath и reclaimPolicy Retain
● Изменен манифест pvc.yaml так, чтобы в нем запрашивалось хранилище созданного выше storageClass


## Как запустить проект:
нужен кластер k8s.
 - склонировать проект, перейти в директорию kubernetes-volumes
 - применить в следующей очередности все файлы:
`kubectl apply -f namespace.yaml -f storageClass.yaml -f pvc.yaml -f cm.yaml -f deployment.yaml -f service.yaml -f ingress.yaml `

## Как проверить работоспособность:
- сменить ns поумолчанию на  homework: `kubectl config set-context --current --namespace=homework`
- получить имя любого пода, выполнить `kubectl describe (имя пода)` убедится в примонтированных volume присутствует pvc `hm-pvc`:
 ```
Volumes: 
  hw-pvc:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  hw-pvc
```
- там же убедиться, что примонтирован созданный configmap:
```
Containers:
  nginx:
    Mounts:
      /homework/conf from hw-configmap (rw)
```
- если запустить sh в контейнере, то по пути /homework/conf/ будут 3 файла `key1  key2  test`

#### задания со *
- выполнить `kubectl describe sc hw`, убедиться что в выводе 
```
Provisioner:         k8s.io/minikube-hostpath
ReclaimPolicy:       Retain
```
 - выполнить `kubectl describe pvc hw-pvc` и убедиться что `StorageClass:  hw`
 

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
